### PR TITLE
Added regex to fix #57

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -787,6 +787,11 @@ function findWithAttr(array, attr, attr2, value) {
 function capitalize(s) {
     return s.toLowerCase().replace(/\b./g, function(a) {
         return a.toUpperCase();
+    }).replace(/(Wb |Eb |Nb |Sb )/g , function (g) {
+        return g.toUpperCase();
+    }).replace(/('[A-z])/g, function (l) {
+        console.log(l);
+        return l.toLowerCase();
     });
 }
 


### PR DESCRIPTION
Created additional replace functionality on `capitalize` function to
check for NB, WB, EB, and SB. Route prefixes should not be hard coded in
the road names.

Provides an expression to remove capitalization from any letter
following an apostrophe.

Fixes #57
